### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Safe Exam Browser/SourceForgeBestReleaseURLProvider.py
+++ b/Safe Exam Browser/SourceForgeBestReleaseURLProvider.py
@@ -19,6 +19,7 @@
 """
 
 from __future__ import absolute_import
+
 import json
 
 from autopkglib import Processor, ProcessorError

--- a/Safe Exam Browser/SourceForgeBestReleaseURLProvider.py
+++ b/Safe Exam Browser/SourceForgeBestReleaseURLProvider.py
@@ -19,10 +19,14 @@
 """
 
 from __future__ import absolute_import
-import urllib2
 import json
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["SourceForgeBestReleaseURLProvider"]
 
@@ -56,8 +60,7 @@ class SourceForgeBestReleaseURLProvider(Processor):
     def get_project_best_release(cls, project_url):
         """Returns the JSON response using the SourceForge Release API"""
         try:
-            request = urllib2.Request(project_url)
-            response = urllib2.urlopen(request)
+            response = urlopen(project_url)
         except BaseException as e:
             raise ProcessorError("Can't open %s: %s" % (project_url, e))
 

--- a/Safe Exam Browser/SourceForgeBestReleaseURLProvider.py
+++ b/Safe Exam Browser/SourceForgeBestReleaseURLProvider.py
@@ -62,7 +62,7 @@ class SourceForgeBestReleaseURLProvider(Processor):
         """Returns the JSON response using the SourceForge Release API"""
         try:
             response = urlopen(project_url)
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't open %s: %s" % (project_url, e))
 
         releases = json.loads(response.read())

--- a/Safe Exam Browser/SourceForgeBestReleaseURLProvider.py
+++ b/Safe Exam Browser/SourceForgeBestReleaseURLProvider.py
@@ -18,6 +18,7 @@
    "Best Release".
 """
 
+from __future__ import absolute_import
 import urllib2
 import json
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.