### PR TITLE
Update SonicPi

### DIFF
--- a/SonicPi/SonicPi.download.recipe
+++ b/SonicPi/SonicPi.download.recipe
@@ -15,7 +15,7 @@ For the ARCH_TYPE variable please use "Intel-Mac-x64" for Intel downloads and "M
         <key>URL</key>
         <string>https://sonic-pi.net/</string>
         <key>ARCH_TYPE</key>
-        <string>Mac-arm64</string>
+        <string></string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.1</string>

--- a/SonicPi/SonicPi.download.recipe
+++ b/SonicPi/SonicPi.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Download recipe for SonicPi</string>
+    <string>Download recipe for SonicPi
+
+For the ARCH_TYPE variable please use "Intel-Mac-x64" for Intel downloads and "Mac-arm64" for Apple Silicon downloads</string>
     <key>Identifier</key>
     <string>com.github.aanklewicz.download.sonicpi</string>
     <key>Input</key>
@@ -12,6 +14,8 @@
         <string>SonicPi</string>
         <key>URL</key>
         <string>https://sonic-pi.net/</string>
+        <key>ARCH_TYPE</key>
+        <string>Mac-arm64</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.3.1</string>
@@ -25,7 +29,7 @@
                 <key>url</key>
                 <string>%URL%</string>
                 <key>re_pattern</key>
-                <string>(files/releases/.*?/Sonic-Pi-for-Mac-.*?.dmg)</string>
+                <string>(files/releases/v([0-9]+(\.[0-9]+)+)/Sonic-Pi-for-%ARCH_TYPE%-v([0-9]+(-[0-9]+)+)\.dmg)</string>
             </dict>
         </dict>
         <dict>
@@ -44,7 +48,7 @@
         <dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
-        	<key>Arguments</key>
+            <key>Arguments</key>
             <dict>
                 <key>input_path</key>
                 <string>%pathname%/Sonic Pi.app</string>

--- a/SonicPi/SonicPi.munki.recipe
+++ b/SonicPi/SonicPi.munki.recipe
@@ -15,7 +15,7 @@ For the SUPPORTED_ARCH variable use "x86_64" for Intel and "arm64" for Apple Sil
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps</string>
         <key>SUPPORTED_ARCH</key>
-        <string>arm64</string>
+        <string></string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>

--- a/SonicPi/SonicPi.munki.recipe
+++ b/SonicPi/SonicPi.munki.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest SonicPi zip and imports into Munki.</string>
+    <string>Downloads the latest SonicPi and imports into Munki.
+
+For the SUPPORTED_ARCH variable use "x86_64" for Intel and "arm64" for Apple Silicon.</string>
     <key>Identifier</key>
     <string>com.github.aanklewicz.munki.sonicpi</string>
     <key>Input</key>
@@ -12,6 +14,8 @@
         <string>SonicPi</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps</string>
+        <key>SUPPORTED_ARCH</key>
+        <string>arm64</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
@@ -28,6 +32,10 @@
             <string>SonicPi</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>supported_architectures</key>
+            <array>
+                <string>%SUPPORTED_ARCH%</string>
+            </array>
             <key>unattended_install</key>
             <true/>
         </dict>


### PR DESCRIPTION
Hi, @aanklewicz 

The SonicPi download recipe is currently only downloading the Apple Silcon version. 

This PR adds support for Intel and Apple Silcon downloads via a `ARCH_TYPE` variable. 

I've also added a varialbe to munki recipe to specifly the supported_architectures key. 

Output from successfile Intel and Apple Silcon runs:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/aanklewicz-recipes/SonicPi/SonicPi.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/aanklewicz-recipes/SonicPi/SonicPi.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/aanklewicz-recipes/SonicPi/SonicPi.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): files/releases/v4.4.0/Sonic-Pi-for-Intel-Mac-x64-v4-4-0.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 27 Jun 2023 22:35:20 GMT
URLDownloader: Storing new ETag header: "649b6428-a5d25bf"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Intel-Mac-x64-v4-4-0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Intel-Mac-x64-v4-4-0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.9i7XtS/Sonic Pi.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.9i7XtS/Sonic Pi.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.9i7XtS/Sonic Pi.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/SonicPi-4.4.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Sonic-Pi-for-Intel-Mac-x64-v4-4-0-4.4.0.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/receipts/SonicPi.munki-receipt-20230628-122812.plist

The following new items were downloaded:
    Download Path                                                                                                          
    -------------                                                                                                          
    /Users/paul/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Intel-Mac-x64-v4-4-0.dmg  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path              Pkg Repo Path                                     Icon Repo Path  
    ----     -------  --------  ------------              -------------                                     --------------  
    SonicPi  4.4.0    testing   apps/SonicPi-4.4.0.plist  apps/Sonic-Pi-for-Intel-Mac-x64-v4-4-0-4.4.0.dmg                  
 



autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/aanklewicz-recipes/SonicPi/SonicPi.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/aanklewicz-recipes/SonicPi/SonicPi.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/aanklewicz-recipes/SonicPi/SonicPi.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (match): files/releases/v4.4.0/Sonic-Pi-for-Mac-arm64-v4-4-0.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 27 Jun 2023 22:16:44 GMT
URLDownloader: Storing new ETag header: "649b5fcc-8c48406"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-arm64-v4-4-0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-arm64-v4-4-0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.dX7g75/Sonic Pi.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.dX7g75/Sonic Pi.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.dX7g75/Sonic Pi.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/SonicPi-4.4.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Sonic-Pi-for-Mac-arm64-v4-4-0-4.4.0.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/receipts/SonicPi.munki-receipt-20230628-123326.plist

The following new items were downloaded:
    Download Path                                                                                                      
    -------------                                                                                                      
    /Users/paul/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-arm64-v4-4-0.dmg  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                 Pkg Repo Path                                 Icon Repo Path  
    ----     -------  --------  ------------                 -------------                                 --------------  
    SonicPi  4.4.0    testing   apps/SonicPi-4.4.0__1.plist  apps/Sonic-Pi-for-Mac-arm64-v4-4-0-4.4.0.dmg
```