### PR TITLE
Deprecate ScaleFT recipes

### DIFF
--- a/ScaleFT/ScaleFT.download.recipe
+++ b/ScaleFT/ScaleFT.download.recipe
@@ -20,6 +20,15 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the ScaleFT recipes in weswhet-recipes. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
 				<string>%NAME%.pkg</string>
 				<key>url</key>

--- a/ScaleFT/ScaleFT.download.recipe
+++ b/ScaleFT/ScaleFT.download.recipe
@@ -14,7 +14,7 @@
 		<string>ScaleFT</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR deprecates the ScaleFT recipes, which are not currently functional, in favor of the functional ones in weswhet-recipes.