### PR TITLE
Update SonicPi.download.recipe

### DIFF
--- a/SonicPi/SonicPi.download.recipe
+++ b/SonicPi/SonicPi.download.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Download recipe for SonicPi
 
-For the ARCH_TYPE variable please use Intel-Mac-x64 for Intel downloads and Mac-arm64 for Apple Silicon downloads</string>
+For the ARCH_TYPE variable please use Mac-x64 for Intel downloads and Mac-arm64 for Apple Silicon downloads</string>
     <key>Identifier</key>
     <string>com.github.aanklewicz.download.sonicpi</string>
     <key>Input</key>
@@ -31,7 +31,7 @@ For the ARCH_TYPE variable please use Intel-Mac-x64 for Intel downloads and Mac-
             <key>Arguments</key>
             <dict>
                 <key>predicate</key>
-                <string>"%ARCH_TYPE%" != "Intel-Mac-x64" AND "%ARCH_TYPE%" != "Mac-arm64"</string>
+                <string>"%ARCH_TYPE%" != "Mac-x64" AND "%ARCH_TYPE%" != "Mac-arm64"</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @aanklewicz 

The recipe is currently failing for any intel runs due to a name change in the dmg. 

This PR updates the predicate and description for the new intel filename. 

Output from successful - v runs

```
autopkg run -v SonicPi.munki.recipe
Looking for com.github.aanklewicz.download.sonicpi...
Did not find com.github.aanklewicz.download.sonicpi in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.aanklewicz.download.sonicpi...
Found com.github.aanklewicz.download.sonicpi in recipe map
**load_recipe time: 0.021758749964646995
Processing SonicPi.munki.recipe...
WARNING: SonicPi.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
StopProcessingIf
StopProcessingIf: ("Mac-arm64" != "Mac-x64" AND "Mac-arm64" != "Mac-arm64") is False
URLTextSearcher
URLTextSearcher: Found matching text (url): https://sonic-pi.net/files/releases/v4.6.0/Sonic-Pi-for-Mac-arm64-v4-6-0.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 27 Jun 2025 12:25:33 GMT
URLDownloader: Storing new ETag header: "685e8dbd-99ec551"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-arm64-v4-6-0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-arm64-v4-6-0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.e24F23/Sonic Pi.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.e24F23/Sonic Pi.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.e24F23/Sonic Pi.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/SonicPi-4.6.0-arm64.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Sonic-Pi-for-Mac-arm64-v4-6-0-4.6.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/receipts/SonicPi.munki-receipt-20250627-161024.plist

The following new items were downloaded:
    Download Path                                                                                                             
    -------------                                                                                                             
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-arm64-v4-6-0.dmg  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                    Pkg Repo Path                                 Icon Repo Path  
    ----     -------  --------  ------------                    -------------                                 --------------  
    SonicPi  4.6.0    testing   apps/SonicPi-4.6.0-arm64.plist  apps/Sonic-Pi-for-Mac-arm64-v4-6-0-4.6.0.dmg
 ```
```
autopkg run -v SonicPi.munki.recipe
Looking for com.github.aanklewicz.download.sonicpi...
Did not find com.github.aanklewicz.download.sonicpi in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.aanklewicz.download.sonicpi...
Found com.github.aanklewicz.download.sonicpi in recipe map
**load_recipe time: 0.010497499955818057
Processing SonicPi.munki.recipe...
WARNING: SonicPi.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
StopProcessingIf
StopProcessingIf: ("Mac-x64" != "Mac-x64" AND "Mac-x64" != "Mac-arm64") is False
URLTextSearcher
URLTextSearcher: Found matching text (url): https://sonic-pi.net/files/releases/v4.6.0/Sonic-Pi-for-Mac-x64-v4-6-0.dmg
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 26 Jun 2025 17:10:09 GMT
URLDownloader: Storing new ETag header: "685d7ef1-b8b18e8"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-x64-v4-6-0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-x64-v4-6-0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.kEF8mR/Sonic Pi.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.kEF8mR/Sonic Pi.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.kEF8mR/Sonic Pi.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/SonicPi-4.6.0-x86_64__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Sonic-Pi-for-Mac-x64-v4-6-0-4.6.0__1.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/receipts/SonicPi.munki-receipt-20250627-161437.plist

The following new items were downloaded:
    Download Path                                                                                                           
    -------------                                                                                                           
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.aanklewicz.munki.sonicpi/downloads/Sonic-Pi-for-Mac-x64-v4-6-0.dmg  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                        Pkg Repo Path                                  Icon Repo Path  
    ----     -------  --------  ------------                        -------------                                  --------------  
    SonicPi  4.6.0    testing   apps/SonicPi-4.6.0-x86_64__1.plist  apps/Sonic-Pi-for-Mac-x64-v4-6-0-4.6.0__1.dmg
```
