### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/GameSalad/GameSalad.pkg.recipe
+++ b/GameSalad/GameSalad.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.GameSalad.download</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Genesys Cloud/genesyscloud.pkg.recipe
+++ b/Genesys Cloud/genesyscloud.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.genesyscloud.download</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Kobo/kobo.pkg.recipe
+++ b/Kobo/kobo.pkg.recipe
@@ -62,8 +62,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/PlexForMac/PlexForMac.pkg.recipe
+++ b/PlexForMac/PlexForMac.pkg.recipe
@@ -64,8 +64,6 @@
                     <string>%RECIPE_CACHE_DIR%</string>
                     <key>id</key>
                     <string>com.plexformac.pkg</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/Safe Exam Browser/SEB.pkg.recipe
+++ b/Safe Exam Browser/SEB.pkg.recipe
@@ -62,8 +62,6 @@
                     <string>%version%</string>
                     <key>id</key>
                     <string>%bundleid%</string>
-                    <key>options</key>
-                    <string>purge_ds_store</string>
                     <key>chown</key>
                     <array>
                         <dict>

--- a/snyk-cli/snyk-cli.pkg.recipe
+++ b/snyk-cli/snyk-cli.pkg.recipe
@@ -100,8 +100,6 @@
 					</array>
 					<key>id</key>
 					<string>com.snyk.snyk-cli</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._