### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Observe AI/ObserveAIScreenRecorder.download.recipe
+++ b/Observe AI/ObserveAIScreenRecorder.download.recipe
@@ -58,6 +58,10 @@
             </dict>
             <dict>
                 <key>Processor</key>
+                <string>EndOfCheckPhase</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>com.github.grahampugh.recipes.commonprocessors/PkgInfoReader</string>
                 <key>Arguments</key>
                 <dict>
@@ -75,10 +79,6 @@
                     <key>pkg_path</key>
                     <string>%RECIPE_CACHE_DIR%/downloads/%NAME%-%version%-%ARCH%.pkg</string>
                 </dict>
-            </dict>
-            <dict>
-                <key>Processor</key>
-                <string>EndOfCheckPhase</string>
             </dict>
             <dict>
                 <key>Arguments</key>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.